### PR TITLE
fix: pin Zed GPUI dependencies to stable-compatible revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,9 +1201,8 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#dde98fa822c59028475850f242a4827ba770e24a"
+source = "git+https://github.com/zed-industries/zed#969a67fcfbf799e68ab00854028228274be847e8"
 dependencies = [
- "gpui_util",
  "indexmap",
  "rustc-hash 2.1.2",
 ]
@@ -1698,7 +1697,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#dde98fa822c59028475850f242a4827ba770e24a"
+source = "git+https://github.com/zed-industries/zed#969a67fcfbf799e68ab00854028228274be847e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2682,7 +2681,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/zed-industries/zed#dde98fa822c59028475850f242a4827ba770e24a"
+source = "git+https://github.com/zed-industries/zed#969a67fcfbf799e68ab00854028228274be847e8"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -2712,7 +2711,6 @@ dependencies = [
  "gpui_macros",
  "gpui_shared_string",
  "gpui_util",
- "heapless",
  "http_client",
  "image",
  "inventory",
@@ -2832,7 +2830,7 @@ dependencies = [
 [[package]]
 name = "gpui_linux"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#dde98fa822c59028475850f242a4827ba770e24a"
+source = "git+https://github.com/zed-industries/zed#969a67fcfbf799e68ab00854028228274be847e8"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -2883,7 +2881,7 @@ dependencies = [
 [[package]]
 name = "gpui_macos"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#dde98fa822c59028475850f242a4827ba770e24a"
+source = "git+https://github.com/zed-industries/zed#969a67fcfbf799e68ab00854028228274be847e8"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -2928,7 +2926,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#dde98fa822c59028475850f242a4827ba770e24a"
+source = "git+https://github.com/zed-industries/zed#969a67fcfbf799e68ab00854028228274be847e8"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -2939,7 +2937,7 @@ dependencies = [
 [[package]]
 name = "gpui_platform"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#dde98fa822c59028475850f242a4827ba770e24a"
+source = "git+https://github.com/zed-industries/zed#969a67fcfbf799e68ab00854028228274be847e8"
 dependencies = [
  "console_error_panic_hook",
  "gpui",
@@ -2952,7 +2950,7 @@ dependencies = [
 [[package]]
 name = "gpui_shared_string"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#dde98fa822c59028475850f242a4827ba770e24a"
+source = "git+https://github.com/zed-industries/zed#969a67fcfbf799e68ab00854028228274be847e8"
 dependencies = [
  "schemars",
  "serde",
@@ -2962,7 +2960,7 @@ dependencies = [
 [[package]]
 name = "gpui_util"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#dde98fa822c59028475850f242a4827ba770e24a"
+source = "git+https://github.com/zed-industries/zed#969a67fcfbf799e68ab00854028228274be847e8"
 dependencies = [
  "anyhow",
  "log",
@@ -2971,7 +2969,7 @@ dependencies = [
 [[package]]
 name = "gpui_web"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#dde98fa822c59028475850f242a4827ba770e24a"
+source = "git+https://github.com/zed-industries/zed#969a67fcfbf799e68ab00854028228274be847e8"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -2995,7 +2993,7 @@ dependencies = [
 [[package]]
 name = "gpui_wgpu"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#dde98fa822c59028475850f242a4827ba770e24a"
+source = "git+https://github.com/zed-industries/zed#969a67fcfbf799e68ab00854028228274be847e8"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3024,7 +3022,7 @@ dependencies = [
 [[package]]
 name = "gpui_windows"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#dde98fa822c59028475850f242a4827ba770e24a"
+source = "git+https://github.com/zed-industries/zed#969a67fcfbf799e68ab00854028228274be847e8"
 dependencies = [
  "accesskit",
  "accesskit_windows",
@@ -3273,7 +3271,7 @@ dependencies = [
 [[package]]
 name = "http_client"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#dde98fa822c59028475850f242a4827ba770e24a"
+source = "git+https://github.com/zed-industries/zed#969a67fcfbf799e68ab00854028228274be847e8"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -4146,7 +4144,7 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#dde98fa822c59028475850f242a4827ba770e24a"
+source = "git+https://github.com/zed-industries/zed#969a67fcfbf799e68ab00854028228274be847e8"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -4194,7 +4192,7 @@ dependencies = [
 [[package]]
 name = "menu"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#dde98fa822c59028475850f242a4827ba770e24a"
+source = "git+https://github.com/zed-industries/zed#969a67fcfbf799e68ab00854028228274be847e8"
 dependencies = [
  "gpui",
 ]
@@ -5079,7 +5077,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "perf"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#dde98fa822c59028475850f242a4827ba770e24a"
+source = "git+https://github.com/zed-industries/zed#969a67fcfbf799e68ab00854028228274be847e8"
 dependencies = [
  "collections",
  "serde",
@@ -5861,7 +5859,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#dde98fa822c59028475850f242a4827ba770e24a"
+source = "git+https://github.com/zed-industries/zed#969a67fcfbf799e68ab00854028228274be847e8"
 dependencies = [
  "derive_refineable",
 ]
@@ -6477,7 +6475,7 @@ dependencies = [
 [[package]]
 name = "scheduler"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#dde98fa822c59028475850f242a4827ba770e24a"
+source = "git+https://github.com/zed-industries/zed#969a67fcfbf799e68ab00854028228274be847e8"
 dependencies = [
  "async-task",
  "backtrace",
@@ -7216,7 +7214,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#dde98fa822c59028475850f242a4827ba770e24a"
+source = "git+https://github.com/zed-industries/zed#969a67fcfbf799e68ab00854028228274be847e8"
 dependencies = [
  "heapless",
  "log",
@@ -8182,7 +8180,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#dde98fa822c59028475850f242a4827ba770e24a"
+source = "git+https://github.com/zed-industries/zed#969a67fcfbf799e68ab00854028228274be847e8"
 dependencies = [
  "anyhow",
  "async-fs",
@@ -8221,7 +8219,7 @@ dependencies = [
 [[package]]
 name = "util_macros"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#dde98fa822c59028475850f242a4827ba770e24a"
+source = "git+https://github.com/zed-industries/zed#969a67fcfbf799e68ab00854028228274be847e8"
 dependencies = [
  "perf",
  "quote",
@@ -10098,7 +10096,7 @@ dependencies = [
 [[package]]
 name = "zlog"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#dde98fa822c59028475850f242a4827ba770e24a"
+source = "git+https://github.com/zed-industries/zed#969a67fcfbf799e68ab00854028228274be847e8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -10127,7 +10125,7 @@ dependencies = [
 [[package]]
 name = "ztracing"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#dde98fa822c59028475850f242a4827ba770e24a"
+source = "git+https://github.com/zed-industries/zed#969a67fcfbf799e68ab00854028228274be847e8"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -10138,7 +10136,7 @@ dependencies = [
 [[package]]
 name = "ztracing_macro"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#dde98fa822c59028475850f242a4827ba770e24a"
+source = "git+https://github.com/zed-industries/zed#969a67fcfbf799e68ab00854028228274be847e8"
 
 [[package]]
 name = "zune-core"


### PR DESCRIPTION
cause the newer version of GPUI use unstable feature `std::hint::cold_path`, it made we can not build success, so pin it to a specific commit.