### PR TITLE
feat: add Ctrl+scroll to zoom terminal font size

### DIFF
--- a/src/terminal/input.rs
+++ b/src/terminal/input.rs
@@ -481,6 +481,20 @@ impl Ashell {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        // Ctrl+scroll → zoom terminal font size
+        if event.modifiers.control {
+            let delta = match event.delta {
+                ScrollDelta::Lines(point) => point.y as f32,
+                ScrollDelta::Pixels(point) => point.y.as_f32() / 100.0,
+            };
+            if delta != 0.0 {
+                self.change_terminal_font_size(delta.signum() * 0.5, cx);
+            }
+            window.prevent_default();
+            cx.stop_propagation();
+            return;
+        }
+
         let Some(active_id) = self.active_tab.clone() else {
             return;
         };


### PR DESCRIPTION
  实现逻辑:

  在 on_terminal_scroll 方法开头，新增 Ctrl 修饰键检测：

  Ctrl + 滚轮向上 → 字体增大 0.5px
  Ctrl + 滚轮向下 → 字体减小 0.5px

  - 字体范围受 change_terminal_font_size 已有的 10.0–24.0px 限制
  - 当 Ctrl 按下时，滚轮不再触发终端历史滚动或鼠标事件转发
  - ScrollDelta::Pixels (触控板) 和 ScrollDelta::Lines (鼠标滚轮) 均受支持
